### PR TITLE
Fixed bug caused with accessing request.bodyFields when Content type is application/json

### DIFF
--- a/lib/src/http/chucker_http_client.dart
+++ b/lib/src/http/chucker_http_client.dart
@@ -97,7 +97,7 @@ class ChuckerHttpClient extends BaseClient {
     dynamic responseBody = '';
 
     if (request is Request && request.contentLength > 0) {
-      requestBody = request.bodyFields;
+      requestBody = _getRequestBody(request);
     }
     try {
       final a = utf8.decode(bytes);
@@ -129,5 +129,13 @@ class ChuckerHttpClient extends BaseClient {
         clientLibrary: 'Http',
       ),
     );
+  }
+
+  dynamic _getRequestBody(Request request) {
+    try {
+      return jsonDecode(request.body);
+    } catch (e, s) {
+      debugPrint(s.toString());
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR is a fix for #https://github.com/syedmurtaza108/chucker-flutter/issues/6 which was caused by accessing request.bodyfields. Accessing bodyFields on request with content type other than application/x-www-form-urlencoded throws a state error. I hereby provided a fix for that with encoding the result of request.body

With this PR, it's ensured that request body with any content type can be accessed without throwing any error.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
