### PR TITLE
Fix share button on ipad.

### DIFF
--- a/lib/src/view/api_detail_page.dart
+++ b/lib/src/view/api_detail_page.dart
@@ -44,7 +44,15 @@ class _ApiDetailsPageState extends State<ApiDetailsPage> {
             ),
             IconButton(
               onPressed: () {
-                Share.share(widget.api.toString());
+                Share.share(
+                  widget.api.toString(),
+                  sharePositionOrigin: Rect.fromLTWH(
+                    0,
+                    0,
+                    MediaQuery.of(context).size.width,
+                    MediaQuery.of(context).size.height / 2,
+                  ),
+                );
               },
               icon: const Icon(Icons.share),
             ),


### PR DESCRIPTION
## Description

Add the sharePositionOrigin parameter when sharing with share_plus to make iPad can share the result.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
