### PR TITLE
feature: Honor background theme on notification background

### DIFF
--- a/lib/src/view/widgets/notification.dart
+++ b/lib/src/view/widgets/notification.dart
@@ -100,7 +100,7 @@ class _NotificationState extends State<Notification>
                     width: 8,
                   ),
                 ),
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.primaryContainer,
                 boxShadow: [
                   BoxShadow(
                     color: Colors.grey.withOpacity(0.5),


### PR DESCRIPTION
## Description

There are applications that use dark theme by default, making very difficult to see the text (like the path) on the chucker notification. The reason is that chucker notification right now has a white background hardcoded.

This change honors the theme configuration of the application itself to avoid the problem described above. Instead of always using a white background now we use the primaryContainer color configured in the ThemeData object.

**Screenshot of the problem before the change**
![Screenshot 2024-11-13 at 1 39 09 p m](https://github.com/user-attachments/assets/45d24a2a-12c1-4fbe-9cff-61b4161e3ff4)

**Screenshot after the change using the same theme as above**
![Screenshot 2024-11-13 at 1 43 07 p m](https://github.com/user-attachments/assets/9e33842c-356f-4c66-8fe4-e4b1e5134dc4)

**Screenshot of the example app with the current theme**
![Screenshot 2024-11-13 at 1 58 31 p m](https://github.com/user-attachments/assets/84fccfa4-5e7e-46e6-b4e2-1319bf9972dc)

**Screenshot without setting a theme**
![Screenshot 2024-11-13 at 1 59 39 p m](https://github.com/user-attachments/assets/2327148b-0dc4-487a-9366-2670095b33c7)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
