### PR TITLE
enhancement: should not await when intercept

### DIFF
--- a/lib/src/interceptors/chopper_interceptor.dart
+++ b/lib/src/interceptors/chopper_interceptor.dart
@@ -98,18 +98,27 @@ class ChuckerChopperInterceptor implements Interceptor {
     Chain<BodyType> chain,
   ) async {
     final response = await chain.proceed(chain.request);
-    final time = DateTime.now();
-    await SharedPreferencesManager.getInstance().getSettings();
-
-    if (ChuckerFlutter.isDebugMode || ChuckerFlutter.showOnRelease) {
-      ChuckerUiHelper.showNotification(
-        method: response.base.request?.method ?? '',
-        statusCode: response.statusCode,
-        path: response.base.request?.url.path ?? '',
-        requestTime: time,
-      );
-      await _saveResponse(response, time);
-    }
+    unawaited(_handleResponse(response));
     return response;
+  }
+
+  Future<void> _handleResponse(Response<dynamic> response) async {
+    try {
+      final time = DateTime.now();
+      await SharedPreferencesManager.getInstance().getSettings();
+
+      if (ChuckerFlutter.isDebugMode || ChuckerFlutter.showOnRelease) {
+        ChuckerUiHelper.showNotification(
+          method: response.base.request?.method ?? '',
+          statusCode: response.statusCode,
+          path: response.base.request?.url.path ?? '',
+          requestTime: time,
+        );
+        await _saveResponse(response, time);
+      }
+    }
+    catch (e) {
+      log('ChuckerFlutter: Error saving response: $e');
+    }
   }
 }

--- a/lib/src/interceptors/http_logging_interceptor.dart
+++ b/lib/src/interceptors/http_logging_interceptor.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer';
 
 import 'package:chopper/chopper.dart';
 import 'package:chucker_flutter/src/loggers/logger.dart';
@@ -10,38 +11,46 @@ class ChuckerHttpLoggingInterceptor implements Interceptor {
   FutureOr<Response<BodyType>> intercept<BodyType>(
     Chain<BodyType> chain,
   ) async {
-    final requestBase = await chain.request.toBaseRequest();
-    Logger.request('${requestBase.method} ${requestBase.url}');
-    requestBase.headers.forEach((k, v) => Logger.request('$k: $v'));
-
-    var bytes = '';
-    if (requestBase is http.Request) {
-      final body = requestBase.body;
-      if (body.isNotEmpty) {
-        Logger.json(body, isRequest: true);
-        bytes = ' (${requestBase.bodyBytes.length}-byte body)';
-      }
-    }
-
-    Logger.request('END ${requestBase.method}$bytes');
-
     final response = await chain.proceed(chain.request);
-
-    final base = response.base.request;
-    Logger.response('${response.statusCode} ${base!.url}');
-
-    response.base.headers.forEach((k, v) => Logger.response('$k: $v'));
-
-    var responseBytes = '';
-    if (response.base is http.Response) {
-      final resp = response.base as http.Response;
-      if (resp.body.isNotEmpty) {
-        Logger.json(resp.body);
-        responseBytes = ' (${response.bodyBytes.length}-byte body)';
-      }
-    }
-
-    Logger.response('END ${base.method}$responseBytes');
+    unawaited(_handleResponse(chain, response));
     return response;
+  }
+
+  Future<void> _handleResponse<BodyType>(
+      Chain<BodyType> chain, Response<dynamic> response) async {
+    try {
+      final requestBase = await chain.request.toBaseRequest();
+      Logger.request('${requestBase.method} ${requestBase.url}');
+      requestBase.headers.forEach((k, v) => Logger.request('$k: $v'));
+
+      var bytes = '';
+      if (requestBase is http.Request) {
+        final body = requestBase.body;
+        if (body.isNotEmpty) {
+          Logger.json(body, isRequest: true);
+          bytes = ' (${requestBase.bodyBytes.length}-byte body)';
+        }
+      }
+
+      Logger.request('END ${requestBase.method}$bytes');
+
+      final base = response.base.request;
+      Logger.response('${response.statusCode} ${base!.url}');
+
+      response.base.headers.forEach((k, v) => Logger.response('$k: $v'));
+
+      var responseBytes = '';
+      if (response.base is http.Response) {
+        final resp = response.base as http.Response;
+        if (resp.body.isNotEmpty) {
+          Logger.json(resp.body);
+          responseBytes = ' (${response.bodyBytes.length}-byte body)';
+        }
+      }
+
+      Logger.response('END ${base.method}$responseBytes');
+    } catch (e) {
+      log('ChuckerFlutter: Error saving response: $e');
+    }
   }
 }


### PR DESCRIPTION
**Context**

The current interceptors for logging requests and responses purpose. Currently, it uses await without try-catch, which may cause two issues:
	1.	Crashes: Unhandled exceptions can disrupt the response pipeline.
	2.	Latency: Synchronous await calls can increase response processing time.

**Changes**:
       1. using unawait when intercept the response -> improve response processing time
       2. add try catch -> make sure that error stay inside the library.

**Testing envidence**: ensure that current functions still work.

https://github.com/user-attachments/assets/e664311e-a052-4e8e-9624-342a2c31efee

