### PR TITLE
[enhancement] Display request parameters to easily distinguish between GraphQL calls

### DIFF
--- a/lib/src/view/tabs/apis_listing.dart
+++ b/lib/src/view/tabs/apis_listing.dart
@@ -51,6 +51,7 @@ class _ApisListingTabViewState extends State<ApisListingTabView> {
           method: api.method,
           path: api.path,
           statusCode: api.statusCode,
+          request: api.request,
           onDelete: widget.onDelete,
           checked: api.checked,
           onChecked: widget.onChecked,

--- a/lib/src/view/widgets/apis_listing_item.dart
+++ b/lib/src/view/widgets/apis_listing_item.dart
@@ -21,6 +21,7 @@ class ApisListingItemWidget extends StatelessWidget {
     required this.onChecked,
     required this.showDelete,
     required this.onPressed,
+    required this.request,
     Key? key,
   }) : super(key: key);
 
@@ -53,6 +54,9 @@ class ApisListingItemWidget extends StatelessWidget {
 
   ///Callback when user presses this instance
   final VoidCallback onPressed;
+
+  ///Request data
+  final dynamic request;
 
   @override
   Widget build(BuildContext context) {
@@ -120,6 +124,14 @@ class ApisListingItemWidget extends StatelessWidget {
                   Text(
                     path,
                     style: context.textTheme.bodySmall!.toBold(),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    request.toString().isEmpty
+                        ? Localization.strings['nA']!
+                        : request.toString(),
+                    style: context.textTheme.bodySmall!.withColor(Colors.grey),
+                    maxLines: 2,
                   ),
                   const SizedBox(height: 8),
                   Text(

--- a/test/src/view/chucker_page_test.dart
+++ b/test/src/view/chucker_page_test.dart
@@ -358,4 +358,58 @@ void main() {
       expect((await sharedPreferencesManager.getAllApiResponses()).length, 0);
     },
   );
+
+  testWidgets(
+    'GraphQL requests should display operation name',
+    (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
+
+      final sharedPreferencesManager = SharedPreferencesManager.getInstance(
+        initData: false,
+      );
+
+      final graphqlRequest = {
+        'query': 'query GetUserData { user { name email } }',
+        'operationName': 'GetUserData',
+        'variables': <String, dynamic>{},
+      };
+
+      final graphqlApi = ApiResponse.mock().copyWith(
+        request: graphqlRequest,
+        path: '/graphql',
+      );
+
+      await sharedPreferencesManager.addApiResponse(graphqlApi);
+
+      await tester.pumpWidget(const MaterialApp(home: ChuckerPage()));
+      await tester.pumpAndSettle();
+
+      const expectedGraphQLString = '{query: query GetUserData { user { name '
+          'email } }, operationName: GetUserData, variables: {}}';
+
+      expect(find.text(expectedGraphQLString), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Empty requests should show N/A',
+    (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
+
+      final sharedPreferencesManager = SharedPreferencesManager.getInstance(
+        initData: false,
+      );
+
+      final emptyRequestApi = ApiResponse.mock().copyWith(
+        request: '',
+      );
+
+      await sharedPreferencesManager.addApiResponse(emptyRequestApi);
+
+      await tester.pumpWidget(const MaterialApp(home: ChuckerPage()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('N/A'), findsWidgets);
+    },
+  );
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Currently, Chucker doesn't  display GraphQL operation/query names in the API listing view, making it impossible to identify specific GraphQL requests without opening each item,
Added displaying request parameters to easily distinguish between GraphQL calls.
![Screenshot 2025-04-15 at 15 46 53](https://github.com/user-attachments/assets/9df0a39e-4adc-406d-b93e-709bad84c02d)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
