### PR TITLE
fix: capture response headers in ChuckerHttpClient

### DIFF
--- a/lib/src/http/chucker_http_client.dart
+++ b/lib/src/http/chucker_http_client.dart
@@ -82,6 +82,7 @@ class ChuckerHttpClient extends BaseClient {
         response.headers['content-type'] ??
             response.headers['Content-Type'] ??
             'N/A',
+        response.headers,
       );
     }
 
@@ -103,6 +104,7 @@ class ChuckerHttpClient extends BaseClient {
     int statusCode,
     double contentLength,
     String contentType,
+    Map<String, String> responseHeaders,
   ) async {
     dynamic requestBody = '';
     dynamic responseBody = '';
@@ -133,7 +135,7 @@ class ChuckerHttpClient extends BaseClient {
         contentType: request.headers['Content-Type'],
         // headers: request.headers.toString(),
         headers: request.headers.cast<String, dynamic>(),
-        responseHeaders: {},
+        responseHeaders: responseHeaders.cast<String, dynamic>(),
         // queryParameters: request.url.queryParameters.toString(),
         queryParameters: request.url.queryParameters,
         receiveTimeout: 0,


### PR DESCRIPTION
## Description

The bare-`http` `ChuckerHttpClient` was passing an empty map for
`responseHeaders` when persisting the saved `ApiResponse`, so the Response
Headers tab in the Chucker overlay was always empty for apps using
`package:http` directly. The Dio and Chopper interceptors already capture
response headers correctly — only this code path was missing it.

This forwards `response.headers` from `send()` into `_saveResponse()` and
stores it on the `ApiResponse`.

One file changed, three lines added, one removed. The existing test suite
passes (299/299).

### Before
```dart
responseHeaders: {},
```

### After
```dart
responseHeaders: responseHeaders.cast<String, dynamic>(),
```

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)