### PR TITLE
feat: replace NavigatorObserver with navigatorKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.9.2
+
+* Add `ChuckerFlutter.navigatorKey` as the recommended integration. Attach it to your root `MaterialApp.navigatorKey` (or `GoRouter`/custom `RouterDelegate`) to make notifications and the inspector work reliably even when the host app uses nested `Navigator`s (e.g. bottom-nav shells, `ShellRoute`, modal flows).
+* Deprecate `ChuckerFlutter.navigatorObserver`. It still works as a fallback so existing apps keep running unchanged, but new integrations should switch to `navigatorKey`.
+
 ## 1.9.1
 
 * chore(deps): update dependency very_good_analysis to v9 by @renovate[bot] in https://github.com/syedmurtaza108/chucker-flutter/pull/124

--- a/README.md
+++ b/README.md
@@ -76,13 +76,56 @@ final client = ChopperClient(
 );
 ```
 
-The very last thing is to connect Chucker Flutter screens to your app. To do so, you only need to add Chucker Flutter's `NavigatorObserver` in your app's `MaterialApp`  e.g.:
+The very last thing is to connect Chucker Flutter screens to your app by wiring `ChuckerFlutter.navigatorKey` into whichever widget owns your root `Navigator`.
+
+**`MaterialApp` (most apps)**
 
 ```dart
 MaterialApp(
-      ...,
-      navigatorObservers: [ChuckerFlutter.navigatorObserver],
+  navigatorKey: ChuckerFlutter.navigatorKey,
+  ...,
+);
 ```
+
+**`MaterialApp.router` with GoRouter**
+
+`MaterialApp.router` does not accept a `navigatorKey` — pass it to `GoRouter` instead:
+
+```dart
+final _router = GoRouter(
+  navigatorKey: ChuckerFlutter.navigatorKey,
+  routes: [...],
+);
+
+MaterialApp.router(
+  routerConfig: _router,
+  ...,
+);
+```
+
+**`MaterialApp.router` with a custom `RouterDelegate`**
+
+Pass `ChuckerFlutter.navigatorKey` to your delegate's constructor and use it as the key on its root `Navigator`:
+
+```dart
+class AppRouterDelegate extends RouterDelegate<...> {
+  AppRouterDelegate() : navigatorKey = ChuckerFlutter.navigatorKey;
+
+  @override
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      key: navigatorKey,
+      pages: [...],
+      onDidRemovePage: ...,
+    );
+  }
+}
+```
+
+> The previous `navigatorObservers: [ChuckerFlutter.navigatorObserver]` integration is deprecated and unreliable with nested navigators — it still works as a fallback so existing apps keep running, but new integrations should use `navigatorKey`.
 
 By default Chucker Flutter only runs in `debug` mode but you can allow it to run in release mode too using its `showOnRelease` property  e.g.:
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,7 +25,7 @@ class App extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      navigatorObservers: [ChuckerFlutter.navigatorObserver],
+      navigatorKey: ChuckerFlutter.navigatorKey,
       theme: ThemeData(
         appBarTheme: const AppBarTheme(backgroundColor: Color(0xFF13B9FF)),
         colorScheme: ColorScheme.fromSwatch(

--- a/lib/src/view/chucker_page.dart
+++ b/lib/src/view/chucker_page.dart
@@ -58,7 +58,7 @@ class _ChuckerPageState extends State<ChuckerPage> {
   Widget build(_) {
     return Scaffold(
       appBar: ChuckerAppBar(
-        onBackPressed: () => ChuckerFlutter.navigatorObserver.navigator?.pop(),
+        onBackPressed: () => ChuckerFlutter.currentNavigator?.pop(),
         actions: [
           Theme(
             data: ThemeData(
@@ -258,7 +258,7 @@ class _ChuckerPageState extends State<ChuckerPage> {
   }
 
   void _openSettings() {
-    ChuckerFlutter.navigatorObserver.navigator?.push(
+    ChuckerFlutter.currentNavigator?.push(
       MaterialPageRoute<void>(
         builder: (_) => Theme(
           data: ThemeData.light(useMaterial3: false),
@@ -269,7 +269,7 @@ class _ChuckerPageState extends State<ChuckerPage> {
   }
 
   void _openDetails(ApiResponse api) {
-    ChuckerFlutter.navigatorObserver.navigator?.push(
+    ChuckerFlutter.currentNavigator?.push(
       MaterialPageRoute<void>(
         builder: (_) => Theme(
           data: ThemeData.light(useMaterial3: false),

--- a/lib/src/view/helper/chucker_ui_helper.dart
+++ b/lib/src/view/helper/chucker_ui_helper.dart
@@ -12,9 +12,11 @@ import 'package:flutter/material.dart';
 
 ///[ChuckerUiHelper] handles the UI part of `chucker_flutter`
 ///
-///You must initialize ChuckerObserver in the `MaterialApp`
-///of your application as it is required to show notification and the screens
-///of `chucker_flutter`
+///You must attach [ChuckerFlutter.navigatorKey] to your root `MaterialApp`'s
+///`navigatorKey` — it is required to show notifications and the screens of
+///`chucker_flutter`. The legacy `ChuckerFlutter.navigatorObserver` is still
+///supported as a fallback but is deprecated and unreliable when the host app
+///uses nested `Navigator`s.
 class ChuckerUiHelper {
   static final List<OverlayEntry?> _overlayEntries = List.empty(growable: true);
 
@@ -42,10 +44,11 @@ ChuckerFlutter: Your notification setting is off. You can turn it on by visiting
       );
       return false;
     }
-    if (ChuckerFlutter.navigatorObserver.navigator == null) {
+    final navigator = _resolveNavigator();
+    if (navigator == null) {
       debugPrint(
         '''
-ChuckerFlutter: You didn't add ChuckerFlutter.navigatorObserver in your material app. Visit https://github.com/syedmurtaza108/chucker-flutter#getting-started for Chucker Integration details.
+ChuckerFlutter: You didn't attach ChuckerFlutter.navigatorKey to your MaterialApp (or the deprecated ChuckerFlutter.navigatorObserver). Visit https://github.com/syedmurtaza108/chucker-flutter#getting-started for Chucker Integration details.
         ''',
       );
       return false;
@@ -59,7 +62,7 @@ ChuckerFlutter: You programmatically vetoed notification behavior. Make sure to 
       return false;
     }
 
-    final overlay = ChuckerFlutter.navigatorObserver.navigator!.overlay;
+    final overlay = navigator.overlay;
     final entry = _createOverlayEntry(method, statusCode, path, requestTime);
     _overlayEntries.add(entry);
     overlay?.insert(entry);
@@ -89,6 +92,18 @@ ChuckerFlutter: You programmatically vetoed notification behavior. Make sure to 
     );
   }
 
+  static NavigatorState? _resolveNavigator() {
+    // currentState requires an initialized widget binding; catch the assertion
+    // that fires when the interceptor is called before runApp (e.g. in tests).
+    NavigatorState? fromKey;
+    try {
+      fromKey = ChuckerFlutter.navigatorKey.currentState;
+    } catch (_) {}
+    return fromKey ??
+        // ignore: deprecated_member_use_from_same_package
+        ChuckerFlutter.navigatorObserver.navigator;
+  }
+
   static void _removeNotification() {
     for (final entry in _overlayEntries) {
       if (entry != null) {
@@ -102,7 +117,16 @@ ChuckerFlutter: You programmatically vetoed notification behavior. Make sure to 
   ///api requests
   static void showChuckerScreen() {
     SharedPreferencesManager.getInstance().getSettings();
-    ChuckerFlutter.navigatorObserver.navigator!.push(
+    final navigator = _resolveNavigator();
+    if (navigator == null) {
+      debugPrint(
+        '''
+ChuckerFlutter: Cannot open Chucker screen — attach ChuckerFlutter.navigatorKey to your MaterialApp. Visit https://github.com/syedmurtaza108/chucker-flutter#getting-started for Chucker Integration details.
+        ''',
+      );
+      return;
+    }
+    navigator.push(
       MaterialPageRoute<void>(
         builder: (context) => MaterialApp(
           key: const Key('chucker_material_app'),
@@ -134,8 +158,29 @@ class ChuckerFlutter {
   ///Prevents instantiation; every member on this type is static.
   const ChuckerFlutter._();
 
-  ///[navigatorObserver] observes the navigation of your app. It must be
-  ///referenced in your MaterialApp widget
+  ///[navigatorKey] is the recommended way to wire `chucker_flutter` into your
+  ///app. Attach it to your root `MaterialApp.navigatorKey` so Chucker can show
+  ///notifications and open its inspector against the root navigator — this
+  ///works reliably even when your app uses nested `Navigator`s (bottom-nav
+  ///shells, `ShellRoute`, modal flows, etc.).
+  ///
+  ///```dart
+  ///MaterialApp(
+  ///  navigatorKey: ChuckerFlutter.navigatorKey,
+  ///  ...,
+  ///)
+  ///```
+  static final navigatorKey = GlobalKey<NavigatorState>();
+
+  ///[navigatorObserver] observes the navigation of your app.
+  ///
+  ///Deprecated: use [navigatorKey] instead. The observer-based integration is
+  ///unreliable with nested `Navigator`s because it tracks whichever navigator
+  ///last fired a route event, which may not be the root one.
+  @Deprecated(
+    'Use ChuckerFlutter.navigatorKey on MaterialApp.navigatorKey instead. '
+    'Observer-based wiring is unreliable with nested Navigators.',
+  )
   static final navigatorObserver = NavigatorObserver();
 
   ///[showOnRelease] decides whether to allow Chucker Flutter working in release
@@ -154,6 +199,11 @@ class ChuckerFlutter {
   static final chuckerButton = (isDebugMode || ChuckerFlutter.showOnRelease)
       ? ChuckerButton.getInstance()
       : const SizedBox.shrink();
+
+  ///Returns the current [NavigatorState] for use by internal Chucker screens.
+  ///Prefers [navigatorKey]; falls back to the deprecated observer.
+  static NavigatorState? get currentNavigator =>
+      ChuckerUiHelper._resolveNavigator();
 
   ///[showChuckerScreen] navigates to the chucker home screen
   static void showChuckerScreen() => ChuckerUiHelper.showChuckerScreen();

--- a/lib/src/view/widgets/notification.dart
+++ b/lib/src/view/widgets/notification.dart
@@ -164,7 +164,7 @@ class _NotificationState extends State<Notification>
     final api = await SharedPreferencesManager.getInstance().getApiResponse(
       widget.requestTime,
     );
-    await ChuckerFlutter.navigatorObserver.navigator?.push(
+    await ChuckerFlutter.currentNavigator?.push(
       MaterialPageRoute<dynamic>(
         builder: (_) => Theme(
           data: ThemeData.light(useMaterial3: false),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chucker_flutter
 description: Chucker Flutter helps you inspect the HTTP(S) requests/responses. It stores data locally and provides a UI for inspecting network calls and sharing their content.
-version: 1.9.1
+version: 1.9.2
 repository: https://github.com/syedmurtaza108/chucker-flutter
 issue_tracker: https://github.com/syedmurtaza108/chucker-flutter/issues
 topics: [http, networking, chucker]

--- a/test/src/view/api_detail_page_test.dart
+++ b/test/src/view/api_detail_page_test.dart
@@ -165,7 +165,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          navigatorObservers: [ChuckerFlutter.navigatorObserver],
+          navigatorKey: ChuckerFlutter.navigatorKey,
           home: const ChuckerPage(),
         ),
       );
@@ -202,7 +202,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          navigatorObservers: [ChuckerFlutter.navigatorObserver],
+          navigatorKey: ChuckerFlutter.navigatorKey,
           home: ApiDetailsPage(api: api),
         ),
       );

--- a/test/src/view/helper/chucker_ui_helper_test.dart
+++ b/test/src/view/helper/chucker_ui_helper_test.dart
@@ -1,14 +1,15 @@
+// ignore_for_file: deprecated_member_use_from_same_package
 import 'package:chucker_flutter/src/view/helper/chucker_ui_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets(
-    'showNotification should show notification when called',
+    'showNotification should show notification when navigatorKey is wired',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          navigatorObservers: [ChuckerFlutter.navigatorObserver],
+          navigatorKey: ChuckerFlutter.navigatorKey,
           home: const SizedBox.shrink(),
         ),
       );
@@ -29,7 +30,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          navigatorObservers: [ChuckerFlutter.navigatorObserver],
+          navigatorKey: ChuckerFlutter.navigatorKey,
           home: ChuckerFlutter.chuckerButton,
         ),
       );
@@ -48,7 +49,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          navigatorObservers: [ChuckerFlutter.navigatorObserver],
+          navigatorKey: ChuckerFlutter.navigatorKey,
           home: const Scaffold(),
         ),
       );
@@ -63,6 +64,57 @@ void main() {
       );
       // ignore: flutter_style_todos
       await tester.pumpAndSettle(const Duration(seconds: 1));
+    },
+  );
+
+  testWidgets(
+    'showNotification still works through deprecated navigatorObserver '
+    'fallback when navigatorKey is not attached',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: [ChuckerFlutter.navigatorObserver],
+          home: const SizedBox.shrink(),
+        ),
+      );
+
+      final shown = ChuckerUiHelper.showNotification(
+        method: 'GET',
+        statusCode: 200,
+        path: '/',
+        requestTime: DateTime.now(),
+      );
+
+      expect(shown, true);
+    },
+  );
+
+  testWidgets(
+    'showNotification attaches to root navigator even when a nested '
+    'Navigator is present in the widget tree',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: ChuckerFlutter.navigatorKey,
+          home: Navigator(
+            onGenerateRoute: (_) => MaterialPageRoute<void>(
+              builder: (_) => const Scaffold(body: SizedBox.shrink()),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final shown = ChuckerUiHelper.showNotification(
+        method: 'GET',
+        statusCode: 200,
+        path: '/',
+        requestTime: DateTime.now(),
+      );
+
+      expect(shown, true);
+      expect(ChuckerUiHelper.notificationShown, true);
     },
   );
 }

--- a/test/src/view/notification_test.dart
+++ b/test/src/view/notification_test.dart
@@ -8,7 +8,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          navigatorObservers: [ChuckerFlutter.navigatorObserver],
+          navigatorKey: ChuckerFlutter.navigatorKey,
           home: Scaffold(appBar: AppBar()),
         ),
       );


### PR DESCRIPTION
## Description
Add ChuckerFlutter.navigatorKey (GlobalKey<NavigatorState>) as the
recommended integration point. The observer-based wiring breaks with
nested Navigators because it tracks whichever navigator last fired a
route event; a GlobalKey on the root MaterialApp resolves this.
- Add ChuckerFlutter.navigatorKey and ChuckerFlutter.currentNavigator
- Route all internal navigator access through a single resolver that
  prefers the key and falls back to the deprecated observer
- Deprecate ChuckerFlutter.navigatorObserver (kept for compatibility)
- Update README with wiring instructions for MaterialApp,
  MaterialApp.router + GoRouter, and custom RouterDelegate
- Update example app and all tests to use navigatorKey
- Add nested-Navigator regression test

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

Fixing #109 