### PR TITLE
fix: encode curl query parameters

### DIFF
--- a/lib/src/models/api_response.dart
+++ b/lib/src/models/api_response.dart
@@ -219,8 +219,8 @@ class ApiResponse {
     // Construct the full URL manually
     final queryParams = queryParameters.isNotEmpty
         ? queryParameters.entries.map((e) {
-            final key = Uri.decodeComponent(e.key);
-            final value = Uri.decodeComponent(e.value.toString());
+            final key = Uri.encodeQueryComponent(e.key);
+            final value = Uri.encodeQueryComponent(e.value.toString());
             return '$key=$value';
           }).join('&')
         : '';

--- a/test/src/models/api_response_test.dart
+++ b/test/src/models/api_response_test.dart
@@ -153,6 +153,21 @@ void main() {
     expect(mockedResponse.toString().isNotEmpty, true);
   });
 
+  test('toCurl should encode unescaped query parameters', () {
+    final response = ApiResponse.mock().copyWith(
+      baseUrl: 'https://example.com',
+      path: '/search',
+      queryParameters: {'query': '中文 100%'},
+    );
+
+    expect(
+      response.toCurl(),
+      contains(
+        'https://example.com/search?query=%E4%B8%AD%E6%96%87+100%25',
+      ),
+    );
+  });
+
   test('hashCode should return request time in milliseconds', () {
     final now = DateTime.now();
     final mockedResponse = getMockedResponse().copyWith(requestTime: now);


### PR DESCRIPTION
## Description

Encode query parameter keys and values when generating the cURL URL instead of decoding the raw values stored by the interceptors.

`Uri.decodeComponent` throws when an unescaped value contains non-ASCII characters or a literal `%`. Encoding the values both prevents the inspector from crashing and matches how HTTP clients serialize query parameters.

Adds a regression test covering Chinese characters, spaces, and a literal percent sign.

Fixes #125.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature which causes existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Verification

- `flutter analyze`
- `flutter test`
