### PR TITLE
Refactor: migrate to material_ui and relax share_plus dependency constraint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,5 @@
 include: package:very_good_analysis/analysis_options.4.0.0.yaml
 
 analyzer:
+  exclude:
+    - build/**

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,8 +3,8 @@ import 'dart:convert';
 import 'package:chucker_flutter/chucker_flutter.dart';
 import 'package:dio/dio.dart';
 import 'package:example/chopper/chopper_service.dart';
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   ChuckerFlutter.configure(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.1"
+    version: "1.9.2"
   clock:
     dependency: transitive
     description:
@@ -192,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   dart_style:
     dependency: transitive
     description:
@@ -344,10 +352,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -408,10 +416,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -420,14 +428,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: "9c0156b0cf8b3f56d365c8ffe051a720be3cae9eec55119f01e01b986ffb7101"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -584,10 +600,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -717,10 +733,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -773,10 +789,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -850,5 +866,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   build_runner: ^2.4.9
   chopper_generator: ^8.4.0
 
+  material_ui: ^1.1.1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Checks whether a number is zero or not
 extension IsNotZeroExtension on num {

--- a/lib/src/localization/localization.dart
+++ b/lib/src/localization/localization.dart
@@ -1,6 +1,7 @@
 import 'package:chucker_flutter/src/view/helper/languages.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart'
+    hide GlobalMaterialLocalizations;
+import 'package:material_ui/material_ui.dart';
 
 part 'localization.ur.dart';
 part 'localization.en.dart';

--- a/lib/src/models/settings.dart
+++ b/lib/src/models/settings.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/view/helper/http_methods.dart';
 import 'package:chucker_flutter/src/view/helper/languages.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///[Settings] is the model to save and retrieve settings from shared preferences
 class Settings {

--- a/lib/src/view/api_detail_page.dart
+++ b/lib/src/view/api_detail_page.dart
@@ -7,8 +7,8 @@ import 'package:chucker_flutter/src/view/json_tree/json_tree.dart';
 import 'package:chucker_flutter/src/view/tabs/overview.dart';
 import 'package:chucker_flutter/src/view/widgets/app_bar.dart';
 import 'package:chucker_flutter/src/view/widgets/sizeable_text_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:share_plus/share_plus.dart';
 
 ///Shows detail of api request and response

--- a/lib/src/view/chucker_page.dart
+++ b/lib/src/view/chucker_page.dart
@@ -11,7 +11,7 @@ import 'package:chucker_flutter/src/view/widgets/app_bar.dart';
 import 'package:chucker_flutter/src/view/widgets/confirmation_dialog.dart';
 import 'package:chucker_flutter/src/view/widgets/filter_buttons.dart';
 import 'package:chucker_flutter/src/view/widgets/menu_buttons.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///The main screen of `chucker_flutter`
 class ChuckerPage extends StatefulWidget {

--- a/lib/src/view/helper/chucker_button.dart
+++ b/lib/src/view/helper/chucker_button.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/view/helper/chucker_ui_helper.dart';
 import 'package:chucker_flutter/src/view/widgets/primary_button.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///[ChuckerButton] can be placed anywhere in the UI to open Chucker Screen
 class ChuckerButton extends StatelessWidget {

--- a/lib/src/view/helper/chucker_ui_helper.dart
+++ b/lib/src/view/helper/chucker_ui_helper.dart
@@ -8,7 +8,7 @@ import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/widgets/notification.dart'
     as notification;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///[ChuckerUiHelper] handles the UI part of `chucker_flutter`
 ///

--- a/lib/src/view/helper/colors.dart
+++ b/lib/src/view/helper/colors.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///main color used for `chucker_flutter`
 const primaryColor = Color(0xFF01569a);

--- a/lib/src/view/image_preview_dialog.dart
+++ b/lib/src/view/image_preview_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/helpers/extensions.dart';
 import 'package:chucker_flutter/src/localization/localization.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///It shows image preview if possible otherwise shows error
 class ImagePreviewDialog extends StatelessWidget {

--- a/lib/src/view/json_tree/json_tree.dart
+++ b/lib/src/view/json_tree/json_tree.dart
@@ -3,8 +3,8 @@ import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/image_preview_dialog.dart';
 import 'package:chucker_flutter/src/view/widgets/sizeable_text_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 part './widgets/json_list.dart';
 part './widgets/json_root.dart';

--- a/lib/src/view/settings_page.dart
+++ b/lib/src/view/settings_page.dart
@@ -10,7 +10,7 @@ import 'package:chucker_flutter/src/view/widgets/alignment_menu.dart';
 import 'package:chucker_flutter/src/view/widgets/app_bar.dart';
 import 'package:chucker_flutter/src/view/widgets/http_methods_menu.dart';
 import 'package:chucker_flutter/src/view/widgets/language_menu.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Chucker Flutter Settings
 class SettingsPage extends StatefulWidget {

--- a/lib/src/view/tabs/apis_listing.dart
+++ b/lib/src/view/tabs/apis_listing.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/models/api_response.dart';
 import 'package:chucker_flutter/src/view/widgets/apis_listing_item.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Shows the listing of api requests
 class ApisListingTabView extends StatefulWidget {

--- a/lib/src/view/tabs/overview.dart
+++ b/lib/src/view/tabs/overview.dart
@@ -5,8 +5,8 @@ import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/models/api_response.dart';
 import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/widgets/sizeable_text_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Shows the api response summary
 class OverviewTabView extends StatelessWidget {

--- a/lib/src/view/widgets/alignment_menu.dart
+++ b/lib/src/view/widgets/alignment_menu.dart
@@ -1,5 +1,5 @@
 import 'package:chucker_flutter/src/view/helper/colors.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Alignment Menu for settings page
 class AlignmentMenu extends StatefulWidget {

--- a/lib/src/view/widgets/apis_listing_item.dart
+++ b/lib/src/view/widgets/apis_listing_item.dart
@@ -3,7 +3,7 @@ import 'package:chucker_flutter/src/localization/localization.dart';
 
 import 'package:chucker_flutter/src/models/api_response.dart';
 import 'package:chucker_flutter/src/view/helper/colors.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///[ApisListingItemWidget] renders the [ApiResponse] items in
 ///`ApisListingTabView`

--- a/lib/src/view/widgets/app_bar.dart
+++ b/lib/src/view/widgets/app_bar.dart
@@ -1,5 +1,5 @@
 import 'package:chucker_flutter/src/view/helper/colors.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Reusable appbar
 class ChuckerAppBar extends StatefulWidget implements PreferredSizeWidget {

--- a/lib/src/view/widgets/confirmation_dialog.dart
+++ b/lib/src/view/widgets/confirmation_dialog.dart
@@ -2,7 +2,7 @@ import 'package:chucker_flutter/src/helpers/extensions.dart';
 import 'package:chucker_flutter/src/localization/localization.dart';
 
 import 'package:chucker_flutter/src/view/widgets/primary_button.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class _ConfirmationDialog extends StatelessWidget {
   const _ConfirmationDialog({

--- a/lib/src/view/widgets/filter_buttons.dart
+++ b/lib/src/view/widgets/filter_buttons.dart
@@ -5,7 +5,7 @@ import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/helper/http_methods.dart';
 import 'package:chucker_flutter/src/view/widgets/http_methods_menu.dart';
 import 'package:chucker_flutter/src/view/widgets/primary_button.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///[FilterButtons] helps filtering api requests in apis listing screen
 class FilterButtons extends StatefulWidget {

--- a/lib/src/view/widgets/http_methods_menu.dart
+++ b/lib/src/view/widgets/http_methods_menu.dart
@@ -3,7 +3,7 @@ import 'package:chucker_flutter/src/localization/localization.dart';
 
 import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/helper/http_methods.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Http Methods Menu
 class HttpMethodsMenu extends StatefulWidget {

--- a/lib/src/view/widgets/language_menu.dart
+++ b/lib/src/view/widgets/language_menu.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/helper/languages.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Languages Menu
 class LanguagesMenu extends StatefulWidget {

--- a/lib/src/view/widgets/menu_buttons.dart
+++ b/lib/src/view/widgets/menu_buttons.dart
@@ -1,5 +1,5 @@
 import 'package:chucker_flutter/src/localization/localization.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Menu items shown on chucker main page
 class MenuButtons extends StatelessWidget {

--- a/lib/src/view/widgets/notification.dart
+++ b/lib/src/view/widgets/notification.dart
@@ -7,7 +7,7 @@ import 'package:chucker_flutter/src/view/api_detail_page.dart';
 import 'package:chucker_flutter/src/view/helper/chucker_ui_helper.dart';
 import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/widgets/primary_button.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Notification widget showing in overlay notification
 class Notification extends StatefulWidget {

--- a/lib/src/view/widgets/primary_button.dart
+++ b/lib/src/view/widgets/primary_button.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/helpers/extensions.dart';
 import 'package:chucker_flutter/src/view/helper/colors.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Reusable elevated button
 class PrimaryButton extends StatelessWidget {

--- a/lib/src/view/widgets/sizeable_text_button.dart
+++ b/lib/src/view/widgets/sizeable_text_button.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/helpers/extensions.dart';
 import 'package:chucker_flutter/src/view/helper/colors.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Resizeable Text Button
 class SizeableTextButton extends StatelessWidget {

--- a/lib/src/view/widgets/stats_tile.dart
+++ b/lib/src/view/widgets/stats_tile.dart
@@ -1,5 +1,5 @@
 import 'package:chucker_flutter/src/helpers/extensions.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 ///Shows statistics of api requests as summary
 class StatsTile extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   dio:
     dependency: "direct main"
     description:
@@ -201,10 +209,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   leak_tracker:
     dependency: transitive
     description:
@@ -249,10 +257,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -261,14 +269,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: "9c0156b0cf8b3f56d365c8ffe051a720be3cae9eec55119f01e01b986ffb7101"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -401,10 +417,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -502,10 +518,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -558,10 +574,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   very_good_analysis:
     dependency: "direct dev"
     description:
@@ -619,5 +635,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   http: ^1.6.0
+  material_ui: ^1.1.1
   share_plus: '>=13.0.0 <14.0.0'
   shared_preferences: ^2.5.3
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   http: ^1.6.0
-  share_plus: ^13.0.0
+  share_plus: '>=13.0.0 <14.0.0'
   shared_preferences: ^2.5.3
 
 dev_dependencies:

--- a/test/src/helpers/extensions_test.dart
+++ b/test/src/helpers/extensions_test.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/helpers/extensions.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   test('`isNotZero` should return true if number is > or < 0', () {

--- a/test/src/models/settings_test.dart
+++ b/test/src/models/settings_test.dart
@@ -1,8 +1,8 @@
 import 'package:chucker_flutter/src/models/settings.dart';
 import 'package:chucker_flutter/src/view/helper/http_methods.dart';
 import 'package:chucker_flutter/src/view/helper/languages.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   Settings getMockedSettings() {

--- a/test/src/view/api_detail_page_test.dart
+++ b/test/src/view/api_detail_page_test.dart
@@ -5,8 +5,8 @@ import 'package:chucker_flutter/src/view/api_detail_page.dart';
 import 'package:chucker_flutter/src/view/chucker_page.dart';
 import 'package:chucker_flutter/src/view/json_tree/json_tree.dart';
 import 'package:chucker_flutter/src/view/widgets/sizeable_text_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {

--- a/test/src/view/chucker_page_test.dart
+++ b/test/src/view/chucker_page_test.dart
@@ -4,8 +4,8 @@ import 'package:chucker_flutter/src/view/chucker_page.dart';
 import 'package:chucker_flutter/src/view/tabs/apis_listing.dart';
 import 'package:chucker_flutter/src/view/widgets/apis_listing_item.dart';
 import 'package:chucker_flutter/src/view/widgets/menu_buttons.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {

--- a/test/src/view/helper/chucker_button_test.dart
+++ b/test/src/view/helper/chucker_button_test.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/view/helper/chucker_button.dart';
 import 'package:chucker_flutter/src/view/widgets/primary_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('ChuckerButton', () {

--- a/test/src/view/helper/chucker_ui_helper_test.dart
+++ b/test/src/view/helper/chucker_ui_helper_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 import 'package:chucker_flutter/src/view/helper/chucker_ui_helper.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets(

--- a/test/src/view/helper/colors_test.dart
+++ b/test/src/view/helper/colors_test.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/view/helper/colors.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   test('Status color should return proper with respect to status code', () {

--- a/test/src/view/helper/helper_test.dart
+++ b/test/src/view/helper/helper_test.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/view/helper/chucker_ui_helper.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets('ChuckerButton should be shown everywhere, where it is placed',

--- a/test/src/view/image_preview_dialog_test.dart
+++ b/test/src/view/image_preview_dialog_test.dart
@@ -1,8 +1,9 @@
 import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/view/image_preview_dialog.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart'
+    hide GlobalMaterialLocalizations;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('ImagePreviewDialog', () {

--- a/test/src/view/json_tree/json_tree_test.dart
+++ b/test/src/view/json_tree/json_tree_test.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/view/json_tree/json_tree.dart';
 import 'package:chucker_flutter/src/view/widgets/sizeable_text_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   bool favoritePersonalitiesButton(Element element) {

--- a/test/src/view/notification_test.dart
+++ b/test/src/view/notification_test.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/view/helper/chucker_ui_helper.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets(

--- a/test/src/view/settings_page_test.dart
+++ b/test/src/view/settings_page_test.dart
@@ -2,8 +2,8 @@ import 'package:chucker_flutter/src/helpers/shared_preferences_manager.dart';
 import 'package:chucker_flutter/src/view/helper/http_methods.dart';
 import 'package:chucker_flutter/src/view/helper/languages.dart';
 import 'package:chucker_flutter/src/view/settings_page.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {

--- a/test/src/view/tabs/overview_test.dart
+++ b/test/src/view/tabs/overview_test.dart
@@ -1,8 +1,8 @@
 import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/models/api_response.dart';
 import 'package:chucker_flutter/src/view/tabs/overview.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('OverviewTabView', () {

--- a/test/src/view/widgets/alignment_menu_test.dart
+++ b/test/src/view/widgets/alignment_menu_test.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/view/widgets/alignment_menu.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('AlignmentMenu', () {

--- a/test/src/view/widgets/apis_listing_item_test.dart
+++ b/test/src/view/widgets/apis_listing_item_test.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/view/widgets/apis_listing_item.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('ApisListingItemWidget', () {

--- a/test/src/view/widgets/app_bar_test.dart
+++ b/test/src/view/widgets/app_bar_test.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/widgets/app_bar.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('ChuckerAppBar', () {

--- a/test/src/view/widgets/confirmation_dialog_test.dart
+++ b/test/src/view/widgets/confirmation_dialog_test.dart
@@ -1,8 +1,9 @@
 import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/view/widgets/confirmation_dialog.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart'
+    hide GlobalMaterialLocalizations;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('ConfirmationDialog', () {

--- a/test/src/view/widgets/http_methods_menu_test.dart
+++ b/test/src/view/widgets/http_methods_menu_test.dart
@@ -1,8 +1,8 @@
 import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/view/helper/http_methods.dart';
 import 'package:chucker_flutter/src/view/widgets/http_methods_menu.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('HttpMethodsMenu', () {

--- a/test/src/view/widgets/language_menu_test.dart
+++ b/test/src/view/widgets/language_menu_test.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/view/helper/languages.dart';
 import 'package:chucker_flutter/src/view/widgets/language_menu.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('LanguagesMenu', () {

--- a/test/src/view/widgets/menu_buttons_test.dart
+++ b/test/src/view/widgets/menu_buttons_test.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/localization/localization.dart';
 import 'package:chucker_flutter/src/view/widgets/menu_buttons.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('MenuButtons', () {

--- a/test/src/view/widgets/primary_button_test.dart
+++ b/test/src/view/widgets/primary_button_test.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/widgets/primary_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('PrimaryButton', () {

--- a/test/src/view/widgets/sizeable_text_button_test.dart
+++ b/test/src/view/widgets/sizeable_text_button_test.dart
@@ -1,7 +1,7 @@
 import 'package:chucker_flutter/src/view/helper/colors.dart';
 import 'package:chucker_flutter/src/view/widgets/sizeable_text_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('SizeableTextButton', () {

--- a/test/src/view/widgets/stats_tile_test.dart
+++ b/test/src/view/widgets/stats_tile_test.dart
@@ -1,6 +1,6 @@
 import 'package:chucker_flutter/src/view/widgets/stats_tile.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   group('StatsTile', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces compatibility updates for the latest Flutter/Dart toolchain and modern UI package modularization:

1. **Migration to `material_ui`**:
   - Replaced direct `package:flutter/material.dart` imports with `package:material_ui/material_ui.dart` across the core library, example app, and test files.
   - Updated localization imports to `hide GlobalMaterialLocalizations` from `flutter_localizations` to avoid conflicts with `material_ui`.
   - Added `material_ui: ^1.1.1` as a dependency in both `pubspec.yaml` and `example/pubspec.yaml`.

2. **Relaxed `share_plus` Version Constraint**:
   - Updated `share_plus` from `^13.0.0` to `'>=13.0.0 <14.0.0'` to provide greater version flexibility and avoid dependency resolution conflicts in consuming projects.

3. **Analyzer Configuration**:
   - Added `build/**` exclusion to `analysis_options.yaml` to prevent analyzer warnings on generated build files.

4. **SDK & Lockfile Updates**:
   - Updated `pubspec.lock` files reflecting upgraded Dart (`>=3.12.0 <4.0.0`) and Flutter (`>=3.44.0`) SDK constraints alongside transitive package updates (`intl`, `meta`, `shared_preferences`, `matcher`, etc.).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
